### PR TITLE
Require wp-cli/wp-cli as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,9 @@
         "psr-4": {"": "src/"},
         "files": [ "cron-command.php" ]
     },
-    "require": {
-        "wp-cli/wp-cli": "*"
-    },
+    "require": {},
     "require-dev": {
+        "wp-cli/wp-cli": "*",
         "behat/behat": "~2.5"
     },
     "extra": {


### PR DESCRIPTION
This is the same implementation as other packages, which means you can
run `composer install --no-dev` to get the autoload without any
installed packages.