### PR TITLE
Convert cron, cron event, and cron schedule help summaries to use third-person singular verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package implements the following commands:
 
 ### wp cron test
 
-Test the WP Cron spawning system and report back its status.
+Tests the WP Cron spawning system and report back its status.
 
 ~~~
 wp cron test 
@@ -35,9 +35,39 @@ returned.
 
 
 
+### wp cron event
+
+Schedules, runs, and deletes WP-Cron events.
+
+~~~
+wp cron event
+~~~
+
+**EXAMPLES**
+
+    # Schedule a new cron event
+    $ wp cron event schedule cron_test
+    Success: Scheduled event with hook 'cron_test' for 2016-05-31 10:19:16 GMT.
+
+    # Run all cron events due right now
+    $ wp cron event run --due-now
+    Success: Executed a total of 2 cron events.
+
+    # Delete the next scheduled cron event
+    $ wp cron event delete cron_test
+    Success: Deleted 2 instances of the cron event 'cron_test'.
+
+    # List scheduled cron events in JSON
+    $ wp cron event list --fields=hook,next_run --format=json
+    [{"hook":"wp_version_check","next_run":"2016-05-31 10:15:13"},{"hook":"wp_update_plugins","next_run":"2016-05-31 10:15:13"},{"hook":"wp_update_themes","next_run":"2016-05-31 10:15:14"}]
+
+
+
+
+
 ### wp cron event delete
 
-Delete the next scheduled cron event for the given hook.
+Deletes the next scheduled cron event for the given hook.
 
 ~~~
 wp cron event delete <hook>
@@ -58,7 +88,7 @@ wp cron event delete <hook>
 
 ### wp cron event list
 
-List scheduled cron events.
+Lists scheduled cron events.
 
 ~~~
 wp cron event list [--fields=<fields>] [--<field>=<value>] [--field=<field>] [--format=<format>]
@@ -124,7 +154,7 @@ These fields are optionally available:
 
 ### wp cron event run
 
-Run the next scheduled cron event for the given hook.
+Runs the next scheduled cron event for the given hook.
 
 ~~~
 wp cron event run [<hook>...] [--due-now] [--all]
@@ -151,7 +181,7 @@ wp cron event run [<hook>...] [--due-now] [--all]
 
 ### wp cron event schedule
 
-Schedule a new cron event.
+Schedules a new cron event.
 
 ~~~
 wp cron event schedule <hook> [<next-run>] [<recurrence>] [--<field>=<value>]
@@ -184,6 +214,30 @@ wp cron event schedule <hook> [<next-run>] [<recurrence>] [--<field>=<value>]
     # Schedule new cron event and pass associative arguments
     $ wp cron event schedule cron_test '+1 hour' --foo=1 --bar=2
     Success: Scheduled event with hook 'cron_test' for 2016-05-31 11:21:35 GMT.
+
+
+
+### wp cron schedule
+
+Gets WP-Cron schedules.
+
+~~~
+wp cron schedule
+~~~
+
+**EXAMPLES**
+
+    # List available cron schedules
+    $ wp cron schedule list
+    +------------+-------------+----------+
+    | name       | display     | interval |
+    +------------+-------------+----------+
+    | hourly     | Once Hourly | 3600     |
+    | twicedaily | Twice Daily | 43200    |
+    | daily      | Once Daily  | 86400    |
+    +------------+-------------+----------+
+
+
 
 
 
@@ -273,7 +327,7 @@ Once you've decided to commit the time to seeing your pull request through, [ple
 
 ## Support
 
-Github issues aren't for general support questions, but there are other venues you can try: http://wp-cli.org/#support
+Github issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
 
 
 *This README.md is generated dynamically from the project's codebase using `wp scaffold package-readme` ([doc](https://github.com/wp-cli/scaffold-package-command#wp-scaffold-package-readme)). To suggest changes, please submit a pull request against the corresponding part of the codebase.*

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package implements the following commands:
 
 ### wp cron test
 
-Tests the WP Cron spawning system and report back its status.
+Tests the WP Cron spawning system and reports back its status.
 
 ~~~
 wp cron test 

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,12 @@
         "bundled": true,
         "commands": [
             "cron test",
+            "cron event",
             "cron event delete",
             "cron event list",
             "cron event run",
             "cron event schedule",
+            "cron schedule",
             "cron schedule list"
         ]
     }

--- a/src/Cron_Command.php
+++ b/src/Cron_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manage WP-Cron events and schedules.
+ * Tests, runs, and deletes WP-Cron events and manages WP-Cron schedules.
  *
  * ## EXAMPLES
  *

--- a/src/Cron_Command.php
+++ b/src/Cron_Command.php
@@ -12,7 +12,7 @@
 class Cron_Command extends WP_CLI_Command {
 
 	/**
-	 * Tests the WP Cron spawning system and report back its status.
+	 * Tests the WP Cron spawning system and reports back its status.
 	 *
 	 * This command tests the spawning system by performing the following steps:
 	 *

--- a/src/Cron_Command.php
+++ b/src/Cron_Command.php
@@ -12,7 +12,7 @@
 class Cron_Command extends WP_CLI_Command {
 
 	/**
-	 * Test the WP Cron spawning system and report back its status.
+	 * Tests the WP Cron spawning system and report back its status.
 	 *
 	 * This command tests the spawning system by performing the following steps:
 	 *
@@ -56,7 +56,7 @@ class Cron_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Spawn a request to `wp-cron.php` and return the response.
+	 * Spawns a request to `wp-cron.php` and return the response.
 	 *
 	 * This function is designed to mimic the functionality in `spawn_cron()`
 	 * with the addition of returning the result of the `wp_remote_post()`

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manage WP-Cron events.
+ * Schedules, runs, and deletes WP-Cron events.
  *
  * ## EXAMPLES
  *
@@ -34,7 +34,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	private static $time_format = 'Y-m-d H:i:s';
 
 	/**
-	 * List scheduled cron events.
+	 * Lists scheduled cron events.
 	 *
 	 * ## OPTIONS
 	 *
@@ -121,7 +121,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Schedule a new cron event.
+	 * Schedules a new cron event.
 	 *
 	 * ## OPTIONS
 	 *
@@ -194,7 +194,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Run the next scheduled cron event for the given hook.
+	 * Runs the next scheduled cron event for the given hook.
 	 *
 	 * ## OPTIONS
 	 *
@@ -292,7 +292,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete the next scheduled cron event for the given hook.
+	 * Deletes the next scheduled cron event for the given hook.
 	 *
 	 * ## OPTIONS
 	 *
@@ -369,7 +369,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Fetch an array of scheduled cron events.
+	 * Fetches an array of scheduled cron events.
 	 *
 	 * @return array|WP_Error An array of event objects, or a WP_Error object if there are no events scheduled.
 	 */
@@ -409,7 +409,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Convert a time interval into human-readable format.
+	 * Converts a time interval into human-readable format.
 	 *
 	 * Similar to WordPress' built-in `human_time_diff()` but returns two time period chunks instead of just one.
 	 *

--- a/src/Cron_Schedule_Command.php
+++ b/src/Cron_Schedule_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manage WP-Cron schedules.
+ * Gets WP-Cron schedules.
  *
  * ## EXAMPLES
  *


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for cron commands and subcommands to use third-person singular verbs, respectively.