### PR TITLE
Adapt config anchor to latest template

### DIFF
--- a/features/cron.feature
+++ b/features/cron.feature
@@ -2,8 +2,7 @@ Feature: Manage WP-Cron events and schedules
 
   Background:
     Given a WP install
-    And I run `wp config set DISABLE_WP_CRON false --raw --type=constant --anchor='// ** MySQL settings - You can get this info from your web host ** //
-'`
+    And I run `wp config set DISABLE_WP_CRON false --raw --type=constant --anchor='// ** MySQL settings - You can get this info from your web host ** //'`
 
   Scenario: Scheduling and then deleting an event
     When I run `wp cron event schedule wp_cli_test_event_1 '+1 hour 5 minutes' --apple=banana`

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -2,7 +2,8 @@ Feature: Manage WP-Cron events and schedules
 
   Background:
     Given a WP install
-    And I run `wp config set DISABLE_WP_CRON false --raw --type=constant --anchor='// ** MySQL settings ** //'`
+    And I run `wp config set DISABLE_WP_CRON false --raw --type=constant --anchor='// ** MySQL settings - You can get this info from your web host ** //
+'`
 
   Scenario: Scheduling and then deleting an event
     When I run `wp cron event schedule wp_cli_test_event_1 '+1 hour 5 minutes' --apple=banana`


### PR DESCRIPTION
The `wp-config.php` file template in `wp-cli/config-command` was changed to the latest Core version in https://github.com/wp-cli/config-command/pull/88/files#diff-3b3595a6d61a35d391495e886987c56aR21