### PR TITLE
Add command to unschedule all events with a given hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,27 +233,6 @@ wp cron event schedule <hook> [<next-run>] [<recurrence>] [--<field>=<value>]
 
 
 
-### wp cron event unschedule
-
-Unchedules cron event on specific hook.
-
-~~~
-wp cron event unschedule <hook>
-~~~
-
-**OPTIONS**
-
-	<hook>
-		The hook name.
-
-**EXAMPLES**
-
-    # Unschedule a cron event on given hook.
-    $ wp cron event unschedule cron_test
-    Success: Unscheduled 2 events with hook 'cron_test'.
-
-
-
 ### wp cron schedule
 
 Gets WP-Cron schedules.
@@ -331,6 +310,27 @@ There are no additional fields.
     # List id of available cron schedule
     $ wp cron schedule list --fields=name --format=ids
     hourly twicedaily daily
+
+
+
+### wp cron event unschedule
+
+Unchedules cron event on specific hook.
+
+~~~
+wp cron event unschedule <hook>
+~~~
+
+**OPTIONS**
+
+	<hook>
+		The hook name.
+
+**EXAMPLES**
+
+    # Unschedule a cron event on given hook.
+    $ wp cron event unschedule cron_test
+    Success: Unscheduled 2 events with hook 'cron_test'.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,27 @@ wp cron event schedule <hook> [<next-run>] [<recurrence>] [--<field>=<value>]
 
 
 
+### wp cron event unschedule
+
+Unchedules cron event on specific hook.
+
+~~~
+wp cron event unschedule <hook>
+~~~
+
+**OPTIONS**
+
+	<hook>
+		The hook name.
+
+**EXAMPLES**
+
+    # Unschedule a cron event on given hook.
+    $ wp cron event unschedule cron_test
+    Success: Unscheduled 2 events with hook 'cron_test'.
+
+
+
 ### wp cron schedule
 
 Gets WP-Cron schedules.

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ There are no additional fields.
 
 ### wp cron event unschedule
 
-Unchedules cron event on specific hook.
+Unschedules all cron events for a given hook.
 
 ~~~
 wp cron event unschedule <hook>
@@ -324,7 +324,7 @@ wp cron event unschedule <hook>
 **OPTIONS**
 
 	<hook>
-		The hook name.
+		Name of the hook for which all events should be unscheduled.
 
 **EXAMPLES**
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
             "cron event run",
             "cron event schedule",
             "cron schedule",
-            "cron schedule list"
+            "cron schedule list",
+            "cron event unschedule"
         ]
     },
     "autoload": {

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -38,7 +38,10 @@ Feature: Manage WP Cron events
       Executed a total of 1 cron event
       """
 
-    When I run `wp cron event unschedule wp_cli_test_event_1`
+  @require-wp-4.9.0
+  Scenario: Unschedule cron event
+    When I run `wp cron event schedule wp_cli_test_event_1 now hourly`
+    And I try `wp cron event unschedule wp_cli_test_event_1`
     Then STDOUT should contain:
       """
       Success: Unscheduled event with hook 'wp_cli_test_event_1'
@@ -48,4 +51,12 @@ Feature: Manage WP Cron events
     Then STDERR should be:
       """
       Error: No event found with hook 'wp_cli_test_event'.
+      """
+
+  @less-than-wp-4.9.0
+  Scenario: Unschedule cron event for WP < 4.9.0 has no effect so should give warning
+    When I try `wp cron event unschedule wp_cli_test_event_1`
+    Then STDOUT should contain:
+      """
+      Error: The 'wp_unschedule_hook' function was only introduced in WordPress 4.9.0.
       """

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -38,8 +38,14 @@ Feature: Manage WP Cron events
       Executed a total of 1 cron event
       """
 
-    When I run `wp cron event unschedule wp_cli_test_event`
+    When I run `wp cron event unschedule wp_cli_test_event_1`
     Then STDOUT should contain:
       """
-      Success: Unscheduled event with hook 'wp_cli_test_event'
+      Success: Unscheduled event with hook 'wp_cli_test_event_1'
+      """
+
+    When I try `wp cron event unschedule wp_cli_test_event`
+    Then STDERR should be:
+      """
+      Error: No event found with hook 'wp_cli_test_event'.
       """

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -54,9 +54,9 @@ Feature: Manage WP Cron events
       """
 
   @less-than-wp-4.9.0
-  Scenario: Unschedule cron event for WP < 4.9.0 has no effect so should give warning
+  Scenario: Unschedule cron event for WP < 4.9.0, wp_unschedule_hook was not included
     When I try `wp cron event unschedule wp_cli_test_event_1`
-    Then STDOUT should contain:
+    Then STDERR should be:
       """
       Error: The 'wp_unschedule_hook' function was only introduced in WordPress 4.9.0.
       """

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -47,12 +47,8 @@ Feature: Manage WP Cron events
       Success: Unscheduled 1 event with hook 'wp_cli_test_event_1'.
       """
 
-    When I run `wp cron event schedule wp_cli_test_event_2 now daily`
-    And I run `wp cron event schedule wp_cli_test_event_2 now daily`
-    Then STDOUT should contain:
-      """
-      Success: Scheduled event with hook 'wp_cli_test_event_2'
-      """
+    When I run `wp cron event schedule wp_cli_test_event_2 now hourly`
+    And I run `wp cron event schedule wp_cli_test_event_2 now hourly`
     And I try `wp cron event unschedule wp_cli_test_event_2`
     Then STDOUT should contain:
       """

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -44,7 +44,19 @@ Feature: Manage WP Cron events
     And I try `wp cron event unschedule wp_cli_test_event_1`
     Then STDOUT should contain:
       """
-      Success: Unscheduled event with hook 'wp_cli_test_event_1'
+      Success: Unscheduled 1 event with hook 'wp_cli_test_event_1'.
+      """
+
+    When I run `wp cron event schedule wp_cli_test_event_2 now daily`
+    And I run `wp cron event schedule wp_cli_test_event_2 now daily`
+    Then STDOUT should contain:
+      """
+      Success: Scheduled event with hook 'wp_cli_test_event_2'
+      """
+    And I try `wp cron event unschedule wp_cli_test_event_2`
+    Then STDOUT should contain:
+      """
+      Success: Unscheduled 2 events with hook 'wp_cli_test_event_2'.
       """
 
     When I try `wp cron event unschedule wp_cli_test_event`

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -44,7 +44,7 @@ Feature: Manage WP Cron events
     And I try `wp cron event unschedule wp_cli_test_event_1`
     Then STDOUT should contain:
       """
-      Success: Unscheduled 1 event with hook 'wp_cli_test_event_1'.
+      Success: Unscheduled 1 event for hook 'wp_cli_test_event_1'.
       """
 
     When I run `wp cron event schedule wp_cli_test_event_2 now hourly`
@@ -52,13 +52,13 @@ Feature: Manage WP Cron events
     And I try `wp cron event unschedule wp_cli_test_event_2`
     Then STDOUT should contain:
       """
-      Success: Unscheduled 2 events with hook 'wp_cli_test_event_2'.
+      Success: Unscheduled 2 events for hook 'wp_cli_test_event_2'.
       """
 
     When I try `wp cron event unschedule wp_cli_test_event`
     Then STDERR should be:
       """
-      Error: No event found with hook 'wp_cli_test_event'.
+      Error: No events found for hook 'wp_cli_test_event'.
       """
 
   @less-than-wp-4.9.0
@@ -66,5 +66,5 @@ Feature: Manage WP Cron events
     When I try `wp cron event unschedule wp_cli_test_event_1`
     Then STDERR should be:
       """
-      Error: The 'wp_unschedule_hook' function was only introduced in WordPress 4.9.0.
+      Error: Unscheduling events is only supported from WordPress 4.9.0 onwards.
       """

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -48,7 +48,7 @@ Feature: Manage WP Cron events
       """
 
     When I run `wp cron event schedule wp_cli_test_event_2 now hourly`
-    And I run `wp cron event schedule wp_cli_test_event_2 now hourly`
+    And I run `wp cron event schedule wp_cli_test_event_2 '+1 hour' hourly`
     And I try `wp cron event unschedule wp_cli_test_event_2`
     Then STDOUT should contain:
       """

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -37,3 +37,9 @@ Feature: Manage WP Cron events
       """
       Executed a total of 1 cron event
       """
+
+    When I run `wp cron event unschedule wp_cli_test_event`
+    Then STDOUT should contain:
+      """
+      Success: Unscheduled event with hook 'wp_cli_test_event'
+      """

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -289,11 +289,19 @@ class Cron_Event_Command extends WP_CLI_Command {
 
 		$unscheduled = wp_unschedule_hook( $hook );
 
-		if ( false !== $unscheduled ) {
-			$message = ( 1 === $unscheduled || 0 === $unscheduled ) ? "Unscheduled event with hook '%2\$s'." : "Unscheduled %1\$d events with hook '%2\$s'.";
-			WP_CLI::success( sprintf( $message, $unscheduled, $hook ) );
+		if ( empty( $unscheduled ) ) {
+			$message = 'Event not unscheduled.';
+
+			// If 0 event found on hook.
+			if ( 0 === $unscheduled ) {
+				$message = "No event found with hook '%1\$s'.";
+			}
+
+			WP_CLI::error( sprintf( $message, $hook ) );
+
 		} else {
-			WP_CLI::error( 'Event not unscheduled.' );
+			$message = ( 1 === $unscheduled ) ? "Unscheduled event with hook '%2\$s'." : "Unscheduled %1\$d events with hook '%2\$s'.";
+			WP_CLI::success( sprintf( $message, $unscheduled, $hook ) );
 		}
 
 	}

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -287,6 +287,10 @@ class Cron_Event_Command extends WP_CLI_Command {
 
 		$hook = $args[0];
 
+		if ( Utils\wp_version_compare( '4.9.0', '<' ) ) {
+			WP_CLI::error( "The 'wp_unschedule_hook' function was only introduced in WordPress 4.9.0." );
+		}
+
 		$unscheduled = wp_unschedule_hook( $hook );
 
 		if ( empty( $unscheduled ) ) {

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -270,12 +270,12 @@ class Cron_Event_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Unchedules cron event on specific hook.
+	 * Unschedules all cron events for a given hook.
 	 *
 	 * ## OPTIONS
 	 *
 	 * <hook>
-	 * : The hook name.
+	 * : Name of the hook for which all events should be unscheduled.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -285,20 +285,20 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 */
 	public function unschedule( $args, $assoc_args ) {
 
-		$hook = $args[0];
+		list( $hook ) = $args;
 
 		if ( Utils\wp_version_compare( '4.9.0', '<' ) ) {
-			WP_CLI::error( "The 'wp_unschedule_hook' function was only introduced in WordPress 4.9.0." );
+			WP_CLI::error( 'Unscheduling events is only supported from WordPress 4.9.0 onwards.' );
 		}
 
 		$unscheduled = wp_unschedule_hook( $hook );
 
 		if ( empty( $unscheduled ) ) {
-			$message = 'Event not unscheduled.';
+			$message = 'Failed to unschedule events for hook \'%1\$s.';
 
 			// If 0 event found on hook.
 			if ( 0 === $unscheduled ) {
-				$message = "No event found with hook '%1\$s'.";
+				$message = "No events found for hook '%1\$s'.";
 			}
 
 			WP_CLI::error( sprintf( $message, $hook ) );
@@ -306,9 +306,9 @@ class Cron_Event_Command extends WP_CLI_Command {
 		} else {
 			WP_CLI::success(
 				sprintf(
-					'Unscheduled %1$d %2$s with hook \'%3$s\'.',
+					'Unscheduled %1$d %2$s for hook \'%3$s\'.',
 					$unscheduled,
-					_n( 'event', 'events', $unscheduled ),
+					Utils\pluralize( 'event', $unscheduled ),
 					$hook
 				)
 			);

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -270,6 +270,35 @@ class Cron_Event_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Unchedules cron event on specific hook.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <hook>
+	 * : The hook name.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Unschedule a cron event on given hook.
+	 *     $ wp cron event unschedule cron_test
+	 *     Success: Unscheduled 2 events with hook 'cron_test'.
+	 */
+	public function unschedule( $args, $assoc_args ) {
+
+		$hook = $args[0];
+
+		$unscheduled = wp_unschedule_hook( $hook );
+
+		if ( false !== $unscheduled ) {
+			$message = ( 1 === $unscheduled || 0 === $unscheduled ) ? "Unscheduled event with hook '%2\$s'." : "Unscheduled %1\$d events with hook '%2\$s'.";
+			WP_CLI::success( sprintf( $message, $unscheduled, $hook ) );
+		} else {
+			WP_CLI::error( 'Event not unscheduled.' );
+		}
+
+	}
+
+	/**
 	 * Executes an event immediately.
 	 *
 	 * @param stdClass $event The event

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -304,8 +304,14 @@ class Cron_Event_Command extends WP_CLI_Command {
 			WP_CLI::error( sprintf( $message, $hook ) );
 
 		} else {
-			$message = ( 1 === $unscheduled ) ? "Unscheduled event with hook '%2\$s'." : "Unscheduled %1\$d events with hook '%2\$s'.";
-			WP_CLI::success( sprintf( $message, $unscheduled, $hook ) );
+			WP_CLI::success(
+				sprintf(
+					'Unscheduled %1$d %2$s with hook \'%3$s\'.',
+					$unscheduled,
+					_n( 'event', 'events', $unscheduled ),
+					$hook
+				)
+			);
 		}
 
 	}


### PR DESCRIPTION
Adds unschedule command - 

`wp cron event unschedule <hook>`

Fixes #48 