### PR TITLE
Enforce PHP 7.4 compatibility in Travis CI

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,3 @@
+# Configuration file for nektos/act.
+# See https://github.com/nektos/act#configuration
+-P ubuntu-latest=shivammathur/node:latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,102 @@
+name: Code Quality Checks
+
+on: pull_request
+
+jobs:
+
+  lint: #-----------------------------------------------------------------------
+    name: Lint PHP files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+
+      - name: Check existence of composer.json file
+        id: check_composer_file
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "composer.json"
+
+      - name: Set up PHP envirnoment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: cs2pr
+
+      - name: Get Composer cache Directory
+        if: steps.check_composer_file.outputs.files_exists == 'true'
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Use Composer cache
+        if: steps.check_composer_file.outputs.files_exists == 'true'
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps['composer-cache'].outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        if: steps.check_composer_file.outputs.files_exists == 'true'
+        run: COMPOSER_ROOT_VERSION=dev-master composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Check existence of vendor/bin/parallel-lint file
+        id: check_linter_file
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "vendor/bin/parallel-lint"
+
+      - name: Run Linter
+        if: steps.check_linter_file.outputs.files_exists == 'true'
+        run: vendor/bin/parallel-lint -j 10 . --exclude vendor --checkstyle | cs2pr
+
+  phpcs: #----------------------------------------------------------------------
+    name: PHPCS
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+
+      - name: Check existence of composer.json & phpcs.xml.dist files
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "composer.json, phpcs.xml.dist"
+
+      - name: Set up PHP envirnoment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: cs2pr
+
+      - name: Get Composer cache Directory
+        if: steps.check_files.outputs.files_exists == 'true'
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Use Composer cache
+        if: steps.check_files.outputs.files_exists == 'true'
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: COMPOSER_ROOT_VERSION=dev-master composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Check existence of vendor/bin/phpcs file
+        id: check_phpcs_binary_file
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "vendor/bin/phpcs"
+
+      - name: Run PHPCS
+        if: steps.check_phpcs_binary_file.outputs.files_exists == 'true'
+        run: vendor/bin/phpcs -q --report=checkstyle | cs2pr

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.3
+php: 7.4
 
 notifications:
   email:
@@ -51,7 +51,7 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
-      php: 7.4snapshot
+      php: 7.4
       env: WP_VERSION=latest
     - stage: test
       php: 7.3
@@ -78,7 +78,3 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
-  allow_failures:
-    - stage: test
-      php: 7.4snapshot
-      env: WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-sudo: false
-dist: trusty
+os: linux
+dist: xenial
 
 language: php
 php: 7.4
+
+services:
+  - mysql
 
 notifications:
   email:
@@ -45,11 +48,6 @@ script:
 
 jobs:
   include:
-    - stage: sniff
-      script:
-        - composer lint
-        - composer phpcs
-      env: BUILD=sniff
     - stage: test
       php: 7.4
       env: WP_VERSION=latest
@@ -71,10 +69,7 @@ jobs:
     - stage: test
       php: 5.6
       env: WP_VERSION=3.7.11
+      dist: trusty
     - stage: test
       php: 5.6
       env: WP_VERSION=trunk
-    - stage: test
-      php: 5.4
-      dist: precise
-      env: WP_VERSION=5.1

--- a/README.md
+++ b/README.md
@@ -311,6 +311,27 @@ There are no additional fields.
     $ wp cron schedule list --fields=name --format=ids
     hourly twicedaily daily
 
+
+
+### wp cron event unschedule
+
+Unschedules all cron events for a given hook.
+
+~~~
+wp cron event unschedule <hook>
+~~~
+
+**OPTIONS**
+
+	<hook>
+		Name of the hook for which all events should be unscheduled.
+
+**EXAMPLES**
+
+    # Unschedule a cron event on given hook.
+    $ wp cron event unschedule cron_test
+    Success: Unscheduled 2 events with hook 'cron_test'.
+
 ## Installing
 
 This package is included with WP-CLI itself, no additional installation necessary.
@@ -343,7 +364,7 @@ Once you've decided to commit the time to seeing your pull request through, [ple
 
 ## Support
 
-Github issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
+GitHub issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
 
 
 *This README.md is generated dynamically from the project's codebase using `wp scaffold package-readme` ([doc](https://github.com/wp-cli/scaffold-package-command#wp-scaffold-package-readme)). To suggest changes, please submit a pull request against the corresponding part of the codebase.*

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
             "cron event run",
             "cron event schedule",
             "cron schedule",
-            "cron schedule list"
+            "cron schedule list",
+            "cron event unschedule"
         ]
     },
     "autoload": {

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -37,3 +37,34 @@ Feature: Manage WP Cron events
       """
       Executed a total of 1 cron event
       """
+
+  @require-wp-4.9.0
+  Scenario: Unschedule cron event
+    When I run `wp cron event schedule wp_cli_test_event_1 now hourly`
+    And I try `wp cron event unschedule wp_cli_test_event_1`
+    Then STDOUT should contain:
+      """
+      Success: Unscheduled 1 event for hook 'wp_cli_test_event_1'.
+      """
+
+    When I run `wp cron event schedule wp_cli_test_event_2 now hourly`
+    And I run `wp cron event schedule wp_cli_test_event_2 '+1 hour' hourly`
+    And I try `wp cron event unschedule wp_cli_test_event_2`
+    Then STDOUT should contain:
+      """
+      Success: Unscheduled 2 events for hook 'wp_cli_test_event_2'.
+      """
+
+    When I try `wp cron event unschedule wp_cli_test_event`
+    Then STDERR should be:
+      """
+      Error: No events found for hook 'wp_cli_test_event'.
+      """
+
+  @less-than-wp-4.9.0
+  Scenario: Unschedule cron event for WP < 4.9.0, wp_unschedule_hook was not included
+    When I try `wp cron event unschedule wp_cli_test_event_1`
+    Then STDERR should be:
+      """
+      Error: Unscheduling events is only supported from WordPress 4.9.0 onwards.
+      """

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -38,7 +38,7 @@
 
 	<!-- For help understanding the `testVersion` configuration setting:
 		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="5.6-"/>
 
 	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
 		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -138,7 +138,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 * : How often the event should recur. See `wp cron schedule list` for available schedule names. Defaults to no recurrence.
 	 *
 	 * [--<field>=<value>]
-	 * : Associative args for the event.
+	 * : Arguments to pass to the hook for the event. <field> should be a numeric key, not a string.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -150,11 +150,14 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 *     $ wp cron event schedule cron_test now hourly
 	 *     Success: Scheduled event with hook 'cron_test' for 2016-05-31 10:20:32 GMT.
 	 *
-	 *     # Schedule new cron event and pass associative arguments
-	 *     $ wp cron event schedule cron_test '+1 hour' --foo=1 --bar=2
+	 *     # Schedule new cron event and pass arguments
+	 *     $ wp cron event schedule cron_test '+1 hour' --0=first-argument --1=second-argument
 	 *     Success: Scheduled event with hook 'cron_test' for 2016-05-31 11:21:35 GMT.
 	 */
 	public function schedule( $args, $assoc_args ) {
+		if ( count( $assoc_args ) && count( array_filter( array_keys( $assoc_args ), 'is_string' ) ) ) {
+			WP_CLI::warning( 'Numeric keys should be used for the hook arguments.' );
+		}
 
 		$hook       = $args[0];
 		$next_run   = Utils\get_flag_value( $args, 1, 'now' );
@@ -267,6 +270,53 @@ class Cron_Event_Command extends WP_CLI_Command {
 
 		$message = ( 1 === $executed ) ? 'Executed a total of %d cron event.' : 'Executed a total of %d cron events.';
 		WP_CLI::success( sprintf( $message, $executed ) );
+	}
+
+	/**
+	 * Unschedules all cron events for a given hook.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <hook>
+	 * : Name of the hook for which all events should be unscheduled.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Unschedule a cron event on given hook.
+	 *     $ wp cron event unschedule cron_test
+	 *     Success: Unscheduled 2 events with hook 'cron_test'.
+	 */
+	public function unschedule( $args, $assoc_args ) {
+
+		list( $hook ) = $args;
+
+		if ( Utils\wp_version_compare( '4.9.0', '<' ) ) {
+			WP_CLI::error( 'Unscheduling events is only supported from WordPress 4.9.0 onwards.' );
+		}
+
+		$unscheduled = wp_unschedule_hook( $hook );
+
+		if ( empty( $unscheduled ) ) {
+			$message = 'Failed to unschedule events for hook \'%1\$s.';
+
+			// If 0 event found on hook.
+			if ( 0 === $unscheduled ) {
+				$message = "No events found for hook '%1\$s'.";
+			}
+
+			WP_CLI::error( sprintf( $message, $hook ) );
+
+		} else {
+			WP_CLI::success(
+				sprintf(
+					'Unscheduled %1$d %2$s for hook \'%3$s\'.',
+					$unscheduled,
+					Utils\pluralize( 'event', $unscheduled ),
+					$hook
+				)
+			);
+		}
+
 	}
 
 	/**
@@ -428,7 +478,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 
 		$since = absint( $since );
 
-		// array of time period chunks
+		// Array of time period chunks.
 		$chunks = array(
 			array( 60 * 60 * 24 * 365, 'year' ),
 			array( 60 * 60 * 24 * 30, 'month' ),
@@ -449,24 +499,24 @@ class Cron_Event_Command extends WP_CLI_Command {
 			$seconds = $chunks[ $i ][0];
 			$name    = $chunks[ $i ][1];
 
-			// finding the biggest chunk (if the chunk fits, break)
+			// Finding the biggest chunk (if the chunk fits, break).
 			$count = floor( $since / $seconds );
 			if ( floatval( 0 ) !== $count ) {
 				break;
 			}
 		}
 
-		// set output var
+		// Set output var.
 		$output = sprintf( '%d %s', $count, Utils\pluralize( $name, absint( $count ) ) );
 
-		// step two: the second chunk
+		// Step two: the second chunk.
 		if ( $i + 1 < $j ) {
 			$seconds2 = $chunks[ $i + 1 ][0];
 			$name2    = $chunks[ $i + 1 ][1];
 
 			$count2 = floor( ( $since - ( $seconds * $count ) ) / $seconds2 );
 			if ( floatval( 0 ) !== $count2 ) {
-				// add to output var
+				// Add to output var.
 				$output .= ' ' . sprintf( '%d %s', $count2, Utils\pluralize( $name2, absint( $count2 ) ) );
 			}
 		}


### PR DESCRIPTION
This PR changes the Travis CI configuration to use PHP 7.4 for all main tests nd switches the PHP 7.4 tests from allowing failures to failing the build on errors.

It will also include any fixes that might be required to get the tests to pass.

Related: https://core.trac.wordpress.org/ticket/49943