### PR TITLE
Promote a non-200 response from the cron spawn test to an error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
     },
     "config": {
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
+        "wp-cli/server-command": "^2.0",
         "wp-cli/wp-cli-tests": "^3.1"
     },
     "config": {

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -189,6 +189,40 @@ Feature: Manage WP-Cron events and schedules
       | name   | interval |
       | hourly | 3600     |
 
+  Scenario: Testing WP-Cron
+    Given a php.ini file:
+      """
+      error_log = {RUN_DIR}/server.log
+      log_errors = on
+      """
+    And I launch in the background `wp server --host=localhost --port=8080 --config=php.ini`
+    And a wp-content/mu-plugins/set_cron_site_url.php file:
+      """
+      <?php
+      add_filter( 'cron_request', static function ( $cron_request_array ) {
+        $cron_request_array['url']               = 'http://localhost:8080';
+        $cron_request_array['args']['sslverify'] = false;
+        return $cron_request_array;
+      } );
+      """
+
+    When I run `wp cron event schedule wp_cli_test_event_1 '+1 hour 5 minutes' --0=banana`
+    Then STDOUT should contain:
+      """
+      Success: Scheduled event with hook 'wp_cli_test_event_1'
+      """
+
+    When I run `wp cron test`
+    Then STDOUT should contain:
+      """
+      Success: WP-Cron spawning is working as expected.
+      """
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And the {RUN_DIR}/server.log file should not exist
+
   Scenario: Run multiple cron events
     When I try `wp cron event run`
     Then STDERR should be:

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -2,7 +2,7 @@ Feature: Manage WP-Cron events and schedules
 
   Background:
     Given a WP install
-    And I run `wp config set DISABLE_WP_CRON false --raw --type=constant --anchor='// ** MySQL settings - You can get this info from your web host ** //'`
+    And I run `wp config set DISABLE_WP_CRON false --raw --type=constant --anchor="if ( ! defined( 'DISABLE_WP_CRON' ) )"`
 
   Scenario: Scheduling and then deleting an event
     When I run `wp cron event schedule wp_cli_test_event_1 '+1 hour 5 minutes' --0=banana`

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -189,13 +189,6 @@ Feature: Manage WP-Cron events and schedules
       | name   | interval |
       | hourly | 3600     |
 
-  Scenario: Testing WP-Cron
-    When I try `wp cron test`
-    Then STDERR should not contain:
-      """
-      Error:
-      """
-
   Scenario: Run multiple cron events
     When I try `wp cron event run`
     Then STDERR should be:

--- a/src/Cron_Command.php
+++ b/src/Cron_Command.php
@@ -50,7 +50,7 @@ class Cron_Command extends WP_CLI_Command {
 		if ( 200 === $code ) {
 			WP_CLI::success( 'WP-Cron spawning is working as expected.' );
 		} else {
-			WP_CLI::warning( sprintf( 'WP-Cron spawn succeeded but returned HTTP status code: %1$s %2$s', $code, $message ) );
+			WP_CLI::error( sprintf( 'WP-Cron spawn returned HTTP status code: %1$s %2$s', $code, $message ) );
 		}
 
 	}


### PR DESCRIPTION
Fixes #65 

Note that the current feature test for testing the cron spawner sends an HTTP request to `example.com` (which is the default domain configured for the tests), so here I'm removing it because it's useless and it's not possible to affect its response. Suggestions welcome for improving this.