### PR TITLE
Use `wp_get_ready_cron_jobs()` for `--due-now` to apply core filter

### DIFF
--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -225,7 +225,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 			WP_CLI::error( 'Please specify one or more cron events, or use --due-now/--all.' );
 		}
 
-		$is_due_now = Utils\get_flag_value( $assoc_args, 'due-now' ) ? true : false;
+		$is_due_now = Utils\get_flag_value( $assoc_args, 'due-now' );
 
 		$events = self::get_cron_events( $is_due_now );
 
@@ -432,13 +432,9 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 */
 	protected static function get_cron_events( $is_due_now = false ) {
 
-		if ( $is_due_now ) {
-			// wp_get_ready_cron_jobs since 5.1.0
-			if ( version_compare( get_bloginfo( 'version' ), '5.1', '>=' ) ) {
-				$crons = wp_get_ready_cron_jobs();
-			} else {
-				$crons = _get_cron_array();
-			}
+		// wp_get_ready_cron_jobs since 5.1.0
+		if ( $is_due_now && function_exists( 'wp_get_ready_cron_jobs' ) ) {
+			$crons = wp_get_ready_cron_jobs();
 		} else {
 			$crons = _get_cron_array();
 		}

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -433,7 +433,12 @@ class Cron_Event_Command extends WP_CLI_Command {
 	protected static function get_cron_events( $is_due_now = false ) {
 
 		if ( $is_due_now ) {
-			$crons = wp_get_ready_cron_jobs();
+			// wp_get_ready_cron_jobs since 5.1.0
+			if ( version_compare( get_bloginfo( 'version' ), '5.1', '>=' ) ) {
+				$crons = wp_get_ready_cron_jobs();
+			} else {
+				$crons = _get_cron_array();
+			}
 		} else {
 			$crons = _get_cron_array();
 		}

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -225,7 +225,9 @@ class Cron_Event_Command extends WP_CLI_Command {
 			WP_CLI::error( 'Please specify one or more cron events, or use --due-now/--all.' );
 		}
 
-		$events = self::get_cron_events();
+		$is_due_now = Utils\get_flag_value( $assoc_args, 'due-now' ) ? true : false;
+
+		$events = self::get_cron_events( $is_due_now );
 
 		if ( is_wp_error( $events ) ) {
 			WP_CLI::error( $events );
@@ -428,12 +430,17 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 *
 	 * @return array|WP_Error An array of event objects, or a WP_Error object if there are no events scheduled.
 	 */
-	protected static function get_cron_events() {
+	protected static function get_cron_events( $is_due_now = false ) {
 
-		$crons  = _get_cron_array();
+		if ( $is_due_now ) {
+			$crons = wp_get_ready_cron_jobs();
+		} else {
+			$crons = _get_cron_array();
+		}
+
 		$events = array();
 
-		if ( empty( $crons ) ) {
+		if ( empty( $crons ) && ! $is_due_now ) {
 			return new WP_Error(
 				'no_events',
 				'You currently have no scheduled cron events.'


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

This PR is to resolve the enhancement so that wp_get_ready_cron_jobs() is used.

I have decided to add a control flag and not refactor two methods for not adding extra code, although it may be formally better to apply 2 different methods.

I have come across the problem that the get_cron_events method returns an error if the $crons array is empty, and this can happen just with wp_get_ready_cron_jobs. Therefore, in order to pass the functional tests, I have added the one that checks that the array is empty only when we are not in the "--due-now" situation.


I have performed the functional tests and they are correct. But I understand that it may be a bad practice to add a control flag. I have justified above the reason for the decision. 

Another alternative that I have ruled out is to simply call the pre_get_ready_cron_jobs filter inside the get_cron_events method. This solution would have the advantage of not adding this flag, but we would still have the hidden problem that the result of the filter could return an empty array and therefore would not pass the functional tests (although in my tests it does). I will upload it in another branch in my repository (with_apply_filter)

Fixes #86