### PR TITLE
Warn instead of fatal when invalid cron event is detected

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
+        "wp-cli/eval-command": "^2.0",
         "wp-cli/server-command": "^2.0",
         "wp-cli/wp-cli-tests": "^3.1"
     },

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -360,3 +360,41 @@ Feature: Manage WP-Cron events and schedules
     Then STDOUT should be CSV containing:
       | hook                   | recurrence    | args                           |
       | wp_cli_test_args_event | Non-repeating | {"foo":"banana","bar":"apple"} |
+
+  Scenario: Warn when an invalid cron event is detected
+    Given a WP install
+    And a update.php file:
+      """
+      <?php
+      $val = array(
+        1647914509 => array(
+          'postindexer_secondpass_cron' => array(
+            '40cd750bba9870f18aada2478b24840a' => array(
+              'schedule' => '5mins',
+              'args' => array(),
+              'interval' => 100,
+            ),
+          ),
+        ),
+        'wp_batch_split_terms' => array(
+          1442323165 => array(
+            '40cd750bba9870f18aada2478b24840a' => array(
+              'schedule' => false,
+              'args' => array()
+            )
+          )
+        )
+      );
+      update_option( 'cron', $val );
+      """
+    And I run `wp eval-file update.php`
+
+    When I run `wp cron event list`
+    Then STDOUT should contain:
+      """
+      postindexer_secondpass_cron
+      """
+    And STDERR should contain:
+      """
+      Warning: Ignoring incorrectly registered cron event "wp_batch_split_terms".
+      """

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -389,7 +389,7 @@ Feature: Manage WP-Cron events and schedules
       """
     And I run `wp eval-file update.php`
 
-    When I run `wp cron event list`
+    When I try `wp cron event list`
     Then STDOUT should contain:
       """
       postindexer_secondpass_cron

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -449,6 +449,13 @@ class Cron_Event_Command extends WP_CLI_Command {
 		}
 
 		foreach ( $crons as $time => $hooks ) {
+
+			// Incorrectly registered cron events can produce a string key.
+			if ( is_string( $time ) ) {
+				WP_CLI::warning( sprintf( 'Ignoring invalid cron event ("%s").', $time ) );
+				continue;
+			}
+
 			foreach ( $hooks as $hook => $hook_events ) {
 				foreach ( $hook_events as $sig => $data ) {
 

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -452,7 +452,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 
 			// Incorrectly registered cron events can produce a string key.
 			if ( is_string( $time ) ) {
-				WP_CLI::warning( sprintf( 'Ignoring invalid cron event ("%s").', $time ) );
+				WP_CLI::warning( sprintf( 'Ignoring incorrectly registered cron event "%s".', $time ) );
 				continue;
 			}
 


### PR DESCRIPTION
See https://github.com/wp-cli/cron-command/issues/92