### PR TITLE
Add `--exclude=<hooks>` argument to `wp cron event run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ wp cron event run [<hook>...] [--due-now] [--exclude=<hooks>] [--all]
 		Run all hooks due right now.
 
 	[--exclude=<hooks>]
-		Comma-separated list of events to exclude.
+		Comma-separated list of hooks to exclude.
 
 	[--all]
 		Run all hooks.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ These fields are optionally available:
 Runs the next scheduled cron event for the given hook.
 
 ~~~
-wp cron event run [<hook>...] [--due-now] [--all]
+wp cron event run [<hook>...] [--due-now] [--exclude=<hooks>] [--all]
 ~~~
 
 **OPTIONS**
@@ -183,6 +183,9 @@ wp cron event run [<hook>...] [--due-now] [--all]
 
 	[--due-now]
 		Run all hooks due right now.
+
+	[--exclude=<hooks>]
+		Comma-separated list of events to exclude.
 
 	[--all]
 		Run all hooks.

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -39,6 +39,12 @@ Feature: Manage WP Cron events
       Executed a total of 1 cron event
       """
 
+    When I run `wp cron event run --due-now --exclude=wp_cli_test_event_2`
+    Then STDOUT should contain:
+      """
+      Executed a total of 0 cron events
+      """
+
   @require-wp-4.9.0
   Scenario: Unschedule cron event
     When I run `wp cron event schedule wp_cli_test_event_1 now hourly`

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -45,6 +45,16 @@ Feature: Manage WP Cron events
       Executed a total of 0 cron events
       """
 
+    When I run `wp cron event run wp_cli_test_event_2 --due-now`
+    Then STDOUT should contain:
+      """
+      Executed the cron event 'wp_cli_test_event_2'
+      """
+    And STDOUT should contain:
+      """
+      Executed a total of 1 cron event
+      """
+
   @require-wp-4.9.0
   Scenario: Unschedule cron event
     When I run `wp cron event schedule wp_cli_test_event_1 now hourly`

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -210,6 +210,9 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 * [--due-now]
 	 * : Run all hooks due right now.
 	 *
+	 * [--exclude=<hooks>]
+	 * : Exclude events of a comma-separated list of hooks.
+	 *
 	 * [--all]
 	 * : Run all hooks.
 	 *
@@ -232,6 +235,20 @@ class Cron_Event_Command extends WP_CLI_Command {
 		if ( is_wp_error( $events ) ) {
 			WP_CLI::error( $events );
 		}
+
+		$exclude = Utils\get_flag_value( $assoc_args, 'exclude' );
+
+		if ( ! empty( $exclude ) ) {
+			$exclude = explode( ',', $exclude );
+		}
+
+		$events = array_filter(
+			$events,
+			function ( $event ) use ( $args, $exclude ) {
+				return ( empty( $args ) || in_array( $event->hook, $args, true ) ) &&
+					( empty( $exclude ) || ! in_array( $event->hook, $exclude, true ) );
+			}
+		);
 
 		$hooks = wp_list_pluck( $events, 'hook' );
 		foreach ( $args as $hook ) {

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -211,7 +211,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 * : Run all hooks due right now.
 	 *
 	 * [--exclude=<hooks>]
-	 * : Comma-separated list of events to exclude.
+	 * : Comma-separated list of hooks to exclude.
 	 *
 	 * [--all]
 	 * : Run all hooks.

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -240,15 +240,17 @@ class Cron_Event_Command extends WP_CLI_Command {
 
 		if ( ! empty( $exclude ) ) {
 			$exclude = explode( ',', $exclude );
-		}
 
-		$events = array_filter(
-			$events,
-			function ( $event ) use ( $args, $exclude ) {
-				return ( empty( $args ) || in_array( $event->hook, $args, true ) ) &&
-					( empty( $exclude ) || ! in_array( $event->hook, $exclude, true ) );
-			}
-		);
+			$events = array_filter(
+				$events,
+				function ( $event ) use ( $args, $exclude ) {
+					if ( in_array( $event->hook, $exclude, true ) ) {
+						return false;
+					}
+					return true;
+				}
+			);
+		}
 
 		$hooks = wp_list_pluck( $events, 'hook' );
 		foreach ( $args as $hook ) {

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -211,7 +211,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 * : Run all hooks due right now.
 	 *
 	 * [--exclude=<hooks>]
-	 * : Exclude events of a comma-separated list of hooks.
+	 * : Comma-separated list of events to exclude.
 	 *
 	 * [--all]
 	 * : Run all hooks.


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
Fix #55  
 - This pull request adds the `--exclude` flag to the `wp cron event run` command.
 - The flag accepts a list of comma separated hooks that will be excluded from the list of events.
 
 Working: 
 - Without the exclude flag 
 
![image](https://github.com/wp-cli/cron-command/assets/53530700/55974fda-14d0-4e2e-ae4d-01cf685868bf)

- With the exclude flag

![image](https://github.com/wp-cli/cron-command/assets/53530700/98c53fbe-4a18-45ff-ae82-3746afb27893)


