### PR TITLE
Add `--all` flag to `cron event delete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ wp cron event
 Deletes all scheduled cron events for the given hook.
 
 ~~~
-wp cron event delete [<hook>...] [--due-now] [--all]
+wp cron event delete [<hook>...] [--due-now] [--exclude=<hooks>] [--all]
 ~~~
 
 **OPTIONS**
@@ -96,6 +96,9 @@ wp cron event delete [<hook>...] [--due-now] [--all]
 
 	[--due-now]
 		Delete all hooks due right now.
+
+	[--exclude=<hooks>]
+		Comma-separated list of hooks to exclude.
 
 	[--all]
 		Delete all hooks.

--- a/README.md
+++ b/README.md
@@ -86,13 +86,19 @@ wp cron event
 Deletes all scheduled cron events for the given hook.
 
 ~~~
-wp cron event delete <hook>
+wp cron event delete [<hook>...] [--due-now] [--all]
 ~~~
 
 **OPTIONS**
 
-	<hook>
-		The hook name.
+	[<hook>...]
+		One or more hooks to delete.
+
+	[--due-now]
+		Delete all hooks due right now.
+
+	[--all]
+		Delete all hooks.
 
 **EXAMPLES**
 

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
         "phpcs": "run-phpcs-tests",
+        "phpcbf": "run-phpcbf-cleanup",
         "phpunit": "run-php-unit-tests",
         "prepare-tests": "install-package-tests",
         "test": [

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -135,7 +135,7 @@ Feature: Manage WP-Cron events and schedules
     When I try `wp cron event delete wp_cli_test_event_5`
     Then STDERR should be:
       """
-      Error: Invalid cron event 'wp_cli_test_event_5'.
+      Error: Invalid cron event 'wp_cli_test_event_5'
       """
 
   Scenario: Scheduling and then running a re-occurring event

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -37,7 +37,8 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_1`
     Then STDOUT should contain:
       """
-      Success: Deleted the cron event 'wp_cli_test_event_1'
+      Deleted the cron event 'wp_cli_test_event_1'
+      Success: Deleted a total of 1 cron event.
       """
 
     When I run `wp cron event list`
@@ -123,7 +124,9 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_5`
     Then STDOUT should be:
       """
-      Success: Deleted 2 instances of the cron event 'wp_cli_test_event_5'.
+      Deleted the cron event 'wp_cli_test_event_5'
+      Deleted the cron event 'wp_cli_test_event_5'
+      Success: Deleted a total of 2 cron events.
       """
 
     When I run `wp cron event list`
@@ -135,7 +138,7 @@ Feature: Manage WP-Cron events and schedules
     When I try `wp cron event delete wp_cli_test_event_5`
     Then STDERR should be:
       """
-      Error: Invalid cron event 'wp_cli_test_event_5'.
+      Error: Invalid cron event 'wp_cli_test_event_5'
       """
 
   Scenario: Scheduling and then running a re-occurring event
@@ -174,7 +177,8 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_2`
     Then STDOUT should contain:
       """
-      Success: Deleted the cron event 'wp_cli_test_event_2'
+      Deleted the cron event 'wp_cli_test_event_2'
+      Success: Deleted a total of 1 cron event.
       """
 
     When I run `wp cron event list`
@@ -397,4 +401,93 @@ Feature: Manage WP-Cron events and schedules
     And STDERR should contain:
       """
       Warning: Ignoring incorrectly registered cron event "wp_batch_split_terms".
+      """
+
+  Scenario: Delete multiple cron events
+    When I run `wp cron event schedule wp_cli_test_event_1 '+1 hour 5 minutes' hourly`
+    Then STDOUT should not be empty
+
+    When I run `wp cron event schedule wp_cli_test_event_2 '+1 hour 5 minutes' hourly`
+    Then STDOUT should not be empty
+
+    When I try `wp cron event delete`
+    Then STDERR should be:
+      """
+      Error: Please specify one or more cron events, or use --due-now/--all.
+      """
+
+    # WP throws a notice here for older versions of core.
+    When I try `wp cron event delete --all`
+    Then STDOUT should contain:
+      """
+      Deleted the cron event 'wp_cli_test_event_1'
+      """
+    And STDOUT should contain:
+      """
+      Deleted the cron event 'wp_cli_test_event_2'
+      """
+    And STDOUT should contain:
+      """
+      Success: Deleted a total of
+      """
+
+    When I run `wp cron event schedule wp_cli_test_event_1 now hourly`
+    Then STDOUT should contain:
+      """
+      Success: Scheduled event with hook 'wp_cli_test_event_1'
+      """
+
+    When I run `wp cron event schedule wp_cli_test_event_2 now hourly`
+    Then STDOUT should contain:
+      """
+      Success: Scheduled event with hook 'wp_cli_test_event_2'
+      """
+
+    When I run `wp cron event schedule wp_cli_test_event_2 '+1 hour 5 minutes' hourly`
+    Then STDOUT should contain:
+      """
+      Success: Scheduled event with hook 'wp_cli_test_event_2'
+      """
+
+    When I run `wp cron event delete wp_cli_test_event_2 --due-now`
+    Then STDOUT should contain:
+      """
+      Deleted the cron event 'wp_cli_test_event_2'
+      """
+    And STDOUT should contain:
+      """
+      Deleted a total of
+      """
+
+    When I run `wp cron event list --hook=wp_cli_test_event_2 --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp cron event delete --due-now`
+    Then STDOUT should contain:
+      """
+      Deleted the cron event 'wp_cli_test_event_1'
+      """
+    And STDOUT should not contain:
+      """
+      Deleted the cron event 'wp_cli_test_event_2'
+      """
+    And STDOUT should contain:
+      """
+      Deleted a total of
+      """
+
+  Scenario: A valid combination of parameters should be present
+    When I try `wp cron event delete --due-now --all`
+      Then STDERR should be:
+      """
+      Error: Please use either --due-now or --all.
+      """
+
+    When I try `wp cron event delete wp_cli_test_event_1 --all`
+    Then STDERR should be:
+      """
+      Error: Please either specify cron events, or use --all.
       """

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -37,7 +37,6 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_1`
     Then STDOUT should contain:
       """
-      Deleted the cron event 'wp_cli_test_event_1'
       Success: Deleted a total of 1 cron event.
       """
 
@@ -124,8 +123,6 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_5`
     Then STDOUT should be:
       """
-      Deleted the cron event 'wp_cli_test_event_5'
-      Deleted the cron event 'wp_cli_test_event_5'
       Success: Deleted a total of 2 cron events.
       """
 
@@ -177,7 +174,6 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_2`
     Then STDOUT should contain:
       """
-      Deleted the cron event 'wp_cli_test_event_2'
       Success: Deleted a total of 1 cron event.
       """
 
@@ -420,15 +416,17 @@ Feature: Manage WP-Cron events and schedules
     When I try `wp cron event delete --all`
     Then STDOUT should contain:
       """
-      Deleted the cron event 'wp_cli_test_event_1'
-      """
-    And STDOUT should contain:
-      """
-      Deleted the cron event 'wp_cli_test_event_2'
-      """
-    And STDOUT should contain:
-      """
       Success: Deleted a total of
+      """
+
+    When I try `wp cron event list`
+    Then STDOUT should not contain:
+      """
+      wp_cli_test_event_1
+      """
+    And STDOUT should not contain:
+      """
+      wp_cli_test_event_2
       """
 
     When I run `wp cron event schedule wp_cli_test_event_1 now hourly`
@@ -452,11 +450,13 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_2 --due-now`
     Then STDOUT should contain:
       """
-      Deleted the cron event 'wp_cli_test_event_2'
+      Deleted a total of 1 cron event
       """
-    And STDOUT should contain:
+
+    When I try `wp cron event list`
+    Then STDOUT should contain:
       """
-      Deleted a total of
+      wp_cli_test_event_2
       """
 
     When I run `wp cron event list --hook=wp_cli_test_event_2 --format=count`
@@ -468,15 +468,17 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete --due-now`
     Then STDOUT should contain:
       """
-      Deleted the cron event 'wp_cli_test_event_1'
+      Success: Deleted a total of
       """
-    And STDOUT should not contain:
+
+    When I try `wp cron event list`
+    Then STDOUT should not contain:
       """
-      Deleted the cron event 'wp_cli_test_event_2'
+      wp_cli_test_event_1
       """
     And STDOUT should contain:
       """
-      Deleted a total of
+      wp_cli_test_event_2
       """
 
     When I run `wp cron event schedule wp_cli_test_event_1 '+1 hour 5 minutes' hourly`
@@ -488,16 +490,22 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete --all --exclude=wp_cli_test_event_1`
     Then STDOUT should contain:
       """
-      Deleted the cron event 'wp_cli_test_event_2'
+      Success: Deleted a total of
+      """
+
+    When I try `wp cron event list`
+    Then STDOUT should not contain:
+      """
+      wp_cli_test_event_2
       """
     And STDOUT should contain:
       """
-      Deleted a total of
+      wp_cli_test_event_1
       """
 
   Scenario: A valid combination of parameters should be present
     When I try `wp cron event delete --due-now --all`
-      Then STDERR should be:
+    Then STDERR should be:
       """
       Error: Please use either --due-now or --all.
       """

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -479,6 +479,22 @@ Feature: Manage WP-Cron events and schedules
       Deleted a total of
       """
 
+    When I run `wp cron event schedule wp_cli_test_event_1 '+1 hour 5 minutes' hourly`
+    Then STDOUT should not be empty
+
+    When I run `wp cron event schedule wp_cli_test_event_2 '+1 hour 5 minutes' hourly`
+    Then STDOUT should not be empty
+
+    When I run `wp cron event delete --all --exclude=wp_cli_test_event_1`
+    Then STDOUT should contain:
+      """
+      Deleted the cron event 'wp_cli_test_event_2'
+      """
+    And STDOUT should contain:
+      """
+      Deleted a total of
+      """
+
   Scenario: A valid combination of parameters should be present
     When I try `wp cron event delete --due-now --all`
       Then STDERR should be:

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -135,7 +135,7 @@ Feature: Manage WP-Cron events and schedules
     When I try `wp cron event delete wp_cli_test_event_5`
     Then STDERR should be:
       """
-      Error: Invalid cron event 'wp_cli_test_event_5'
+      Error: Invalid cron event 'wp_cli_test_event_5'.
       """
 
   Scenario: Scheduling and then running a re-occurring event

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -325,7 +325,6 @@ class Cron_Event_Command extends WP_CLI_Command {
 			$result = self::delete_event( $event );
 			if ( $result ) {
 				$deleted++;
-				WP_CLI::log( sprintf( "Deleted the cron event '%s'", $event->hook ) );
 			}
 		}
 

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -288,32 +288,6 @@ class Cron_Event_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Executes an event immediately.
-	 *
-	 * @param stdClass $event The event
-	 * @return bool Whether the event was successfully executed or not.
-	 */
-	protected static function run_event( stdClass $event ) {
-
-		if ( ! defined( 'DOING_CRON' ) ) {
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Using native WordPress constant.
-			define( 'DOING_CRON', true );
-		}
-
-		if ( false !== $event->schedule ) {
-			$new_args = array( $event->time, $event->schedule, $event->hook, $event->args );
-			call_user_func_array( 'wp_reschedule_event', $new_args );
-		}
-
-		wp_unschedule_event( $event->time, $event->hook, $event->args );
-
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- Can't prefix dynamic hooks here, calling registered hooks.
-		do_action_ref_array( $event->hook, $event->args );
-
-		return true;
-	}
-
-	/**
 	 * Deletes all scheduled cron events for the given hook.
 	 *
 	 * ## OPTIONS
@@ -345,13 +319,11 @@ class Cron_Event_Command extends WP_CLI_Command {
 
 		$deleted = 0;
 		foreach ( $events as $event ) {
-			if ( $event->hook === $hook ) {
-				$result = self::delete_event( $event );
-				if ( $result ) {
-					++$deleted;
-				} else {
-					WP_CLI::warning( sprintf( "Failed to the delete the cron event '%s'.", $hook ) );
-				}
+			$result = self::delete_event( $event );
+			if ( $result ) {
+				++$deleted;
+			} else {
+				WP_CLI::warning( sprintf( "Failed to the delete the cron event '%s'.", $hook ) );
 			}
 		}
 

--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -323,7 +323,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 			if ( $result ) {
 				++$deleted;
 			} else {
-				WP_CLI::warning( sprintf( "Failed to the delete the cron event '%s'.", $hook ) );
+				WP_CLI::warning( sprintf( "Failed to the delete the cron event '%s'.", $event->hook ) );
 			}
 		}
 


### PR DESCRIPTION
This is a redo of #81 

Fixes #39 by making the command more consistent with the `wp cron event run` command.

It is now possible to delete multiple cron events at once by either:
- Specifying multiple hooks that need to be deleted:
```
$ wp cron event delete wp_version_check wp_update_plugins
```

- Delete all cron events that are due now
```
$ wp cron event delete --due-now
``` 

- Delete all cron events at once
```
$ wp cron event delete --all
``` 

Since the selection process of the `run` and `delete` command is now the same, a separate function has been added to filter the required hooks (`::get_selected_cron_events()`).

This function now also includes support for the `--exclude` parameter added in #97.