### PR TITLE
Fix incorrect recurrence display for events with invalid schedules

### DIFF
--- a/src/Cron_Event_Command.php
+++ b/src/Cron_Event_Command.php
@@ -436,10 +436,11 @@ class Cron_Event_Command extends WP_CLI_Command {
 	 */
 	protected static function format_event( stdClass $event ) {
 
+		$schedules                = wp_get_schedules();
+		$event->recurrence        = ( isset( $schedules[ $event->schedule ] ) ) ? self::interval( $event->interval ) : 'Non-repeating';
 		$event->next_run          = get_date_from_gmt( date( 'Y-m-d H:i:s', $event->time ), self::$time_format ); //phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		$event->next_run_gmt      = date( self::$time_format, $event->time ); //phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		$event->next_run_relative = self::interval( $event->time - time() );
-		$event->recurrence        = ( $event->schedule ) ? self::interval( $event->interval ) : 'Non-repeating';
 
 		return $event;
 	}


### PR DESCRIPTION
## Overview
This pull request is address issue reported in [#52](https://github.com/wp-cli/cron-command/issues/52), where a cron event with invalid schedule was showing invalid information in the recurrence column.

## Changes
- A Test-Driven Development (TDD) approach is used for write tests first, reproducing the issue.
- Code has been updated for handling scenario where schedule was previously valid but no longer exists.
- If recurrence schedule for event is missing, recurrence column now display "Non-repeating", adhering to user expectations.

## Details
- Modified `Cron_Event_Command` class to check if schedule exists before formatting recurrence.
- Added scenario in feature tests for cover both cases where schedule exists and where it not.

## Testing
The pull request include new test cases that cover described scenario, ensure that recurrence display is handled correct.

## Impact
This fix make better reliability of `wp cron event list` command, providing accurate informations about event recurrence.

I kindly request review of these changes, and I'm available for any further discussion or adjustments as needed.

I would like to also thank @schlessera and @danielbachhuber for the support provided during 2023 WordCamp US Contributor Day.

Related https://github.com/wp-cli/wp-cli/issues/5832