### PR TITLE
Tests that show register shutdown function issue (#70) is invalid

### DIFF
--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -102,7 +102,7 @@ Feature: Manage WP Cron events
       """
 
     When I run `wp cron event schedule mycron now`
-    And I run `wp cron event run --due-now`
+    And I try `wp cron event run --due-now`
     Then STDOUT should contain:
       """
       MY SHUTDOWN FUNCTION
@@ -129,7 +129,7 @@ Feature: Manage WP Cron events
     And I try `wp cron event run --due-now`
     Then STDERR should contain:
       """
-       Fatal error: Uncaught Error: Call to undefined function breakthings()
+      Fatal error: Uncaught Error: Call to undefined function breakthings()
       """
     Then the {RUN_DIR}/server.log file should exist
     And the {RUN_DIR}/server.log file should contain:

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -85,3 +85,54 @@ Feature: Manage WP Cron events
       """
       Error: Unscheduling events is only supported from WordPress 4.9.0 onwards.
       """
+
+  Scenario: Run cron event with a registered shutdown function
+    Given a wp-content/mu-plugins/setup_shutdown_function.php file:
+      """
+      add_action('mycron', function() {
+        breakthings();
+      });
+
+      register_shutdown_function(function() {
+        $error = error_get_last();
+        if ($error['type'] === E_ERROR) {
+          WP_CLI::line('MY SHUTDOWN FUNCTION');
+        }
+        });
+      """
+
+    When I run `wp cron event schedule mycron now`
+    And I run `wp cron event run --due-now`
+    Then STDOUT should contain:
+      """
+      MY SHUTDOWN FUNCTION
+      """
+
+  Scenario: Run cron event with a registered shutdown function that logs to a file
+    Given a wp-content/mu-plugins/setup_shutdown_function_log.php file:
+      """
+      <?php
+      add_action('mycronlog', function() {
+        breakthings();
+      });
+
+      register_shutdown_function(function() {
+        error_log('LOG A SHUTDOWN FROM ERROR');
+        // file_put_contents( dirname( __FILE__ ) . '/log.log', print_r( 'Shutdown called correctly', true ) . "\r\n\r\n", FILE_APPEND );
+      });
+      """
+
+    And I run `wp config set WP_DEBUG true --raw`
+    And I run `wp config set WP_DEBUG_LOG '{RUN_DIR}/server.log'`
+
+    When I run `wp cron event schedule mycronlog now`
+    And I try `wp cron event run --due-now`
+    Then STDERR should contain:
+      """
+       Fatal error: Uncaught Error: Call to undefined function breakthings()
+      """
+    Then the {RUN_DIR}/server.log file should exist
+    And the {RUN_DIR}/server.log file should contain:
+      """
+      LOG A SHUTDOWN FROM ERROR
+      """

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -123,10 +123,9 @@ Feature: Manage WP Cron events
       """
 
     And I run `wp config set WP_DEBUG true --raw`
-    And I run `wp config set WP_DEBUG_DISPLAY false --raw`
     And I run `wp config set WP_DEBUG_LOG '{RUN_DIR}/server.log'`
 
-    When I run `wp cron event schedule mycronlog now`
+    When I try `wp cron event schedule mycronlog now`
     And I try `wp cron event run --due-now`
     Then STDERR should contain:
       """

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -118,7 +118,6 @@ Feature: Manage WP Cron events
 
       register_shutdown_function(function() {
         error_log('LOG A SHUTDOWN FROM ERROR');
-        // file_put_contents( dirname( __FILE__ ) . '/log.log', print_r( 'Shutdown called correctly', true ) . "\r\n\r\n", FILE_APPEND );
       });
       """
 

--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -123,13 +123,14 @@ Feature: Manage WP Cron events
       """
 
     And I run `wp config set WP_DEBUG true --raw`
+    And I run `wp config set WP_DEBUG_DISPLAY false --raw`
     And I run `wp config set WP_DEBUG_LOG '{RUN_DIR}/server.log'`
 
     When I run `wp cron event schedule mycronlog now`
     And I try `wp cron event run --due-now`
     Then STDERR should contain:
       """
-      Fatal error: Uncaught Error: Call to undefined function breakthings()
+      Call to undefined function breakthings()
       """
     Then the {RUN_DIR}/server.log file should exist
     And the {RUN_DIR}/server.log file should contain:


### PR DESCRIPTION
This addresses #70. This one is sort of complicated to reproduce accurately, but these tests demonstrate that a registered shutdown function _is_ capable of writing to a file, so **the reported issue is invalid,** and can probably be safely closed as a "will not fix". Brian and I decided that we preferred the `error_log()` demonstration over `file_put_contents()` for Behat, but we tested both ways and the result was the same.

Submitted during [Contributor Day](https://github.com/wp-cli/wp-cli/issues/5985).
