### PR TITLE
Harden test checking for log file

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,3 +13,5 @@ on:
 jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
+    with:
+      minimum-php: '8.3'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,5 +13,3 @@ on:
 jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
-    with:
-      minimum-php: '8.3'

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -260,7 +260,7 @@ Feature: Manage WP-Cron events and schedules
     # the following warning might be added to the log file:
     # PHP Warning: JIT is incompatible with third party extensions that override zend_execute_ex(). JIT disabled. in Unknown on line 0
     # This workaround checks for any other possible entries in the log file.
-    When I run `awk '!/JIT/' {RUN_DIR}/server.log 2>/dev/null`
+    When I run `awk '!/JIT/' {RUN_DIR}/server.log 2>/dev/null || echo ""`
     Then STDOUT should be empty
 
   Scenario: Run multiple cron events

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -255,12 +255,13 @@ Feature: Manage WP-Cron events and schedules
       """
       Error:
       """
-    When I run `cat {RUN_DIR}/server.log`
-    Then STDOUT should contain:
-    """
-    foo
-    """
-    And the {RUN_DIR}/server.log file should not exist
+
+    # Normally we would simply check for the log file to not exist. However, when running with Xdebug for code coverage purposes,
+    # the following warning might be added to the log file:
+    # PHP Warning: JIT is incompatible with third party extensions that override zend_execute_ex(). JIT disabled. in Unknown on line 0
+    # This workaround checks for any other possible entries in the log file.
+    When I run `awk '!/JIT/' {RUN_DIR}/server.log 2>/dev/null`
+    Then STDOUT should be empty
 
   Scenario: Run multiple cron events
     When I try `wp cron event run`

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -260,7 +260,7 @@ Feature: Manage WP-Cron events and schedules
     # the following warning might be added to the log file:
     # PHP Warning: JIT is incompatible with third party extensions that override zend_execute_ex(). JIT disabled. in Unknown on line 0
     # This workaround checks for any other possible entries in the log file.
-    When I run `awk '!/JIT/' {RUN_DIR}/server.log 2>/dev/null || echo ""`
+    When I run `awk '!/JIT/' {RUN_DIR}/server.log 2>/dev/null || true`
     Then STDOUT should be empty
 
   Scenario: Run multiple cron events

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -255,6 +255,11 @@ Feature: Manage WP-Cron events and schedules
       """
       Error:
       """
+    When I run `cat {RUN_DIR}/server.log`
+    Then STDOUT should contain:
+    """
+    foo
+    """
     And the {RUN_DIR}/server.log file should not exist
 
   Scenario: Run multiple cron events


### PR DESCRIPTION
This test started to fail with the introduction of Behat code coverage collection support, where the log file was suddenly filled with a warning caused by Xdebug.

This adds hardening and explanatory code comment.