### PR TITLE
Flush dynamically scheduled core cron events in Behat tests

### DIFF
--- a/features/cron-event.feature
+++ b/features/cron-event.feature
@@ -14,6 +14,13 @@ Feature: Manage WP Cron events
       Success: Executed a total of
       """
 
+    # Running --all in WP >= 6.3 dynamically schedules 'wp_delete_temp_updater_backups' for now.
+    When I try `wp cron event run --due-now`
+    Then STDOUT should contain:
+      """
+      Success: Executed a total of
+      """
+
     When I run `wp cron event run --due-now`
     Then STDOUT should contain:
       """

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -333,6 +333,13 @@ Feature: Manage WP-Cron events and schedules
       Success: Executed a total of
       """
 
+    # Running --all in WP >= 6.3 dynamically schedules 'wp_delete_temp_updater_backups' for now.
+    When I try `wp cron event run --due-now`
+    Then STDOUT should contain:
+      """
+      Success: Executed a total of
+      """
+
     When I run `wp cron event run --due-now`
     Then STDOUT should contain:
       """


### PR DESCRIPTION
### Description

In WordPress 6.3.0+, WordPress core introduced the `wp_delete_temp_updater_backups` cron hook. This hook is dynamically scheduled for `time()` (now) when `WP_Upgrader` is first instantiated on a site (which occurs when `wp_version_check` executes and finds update/translation offers from `api.wordpress.org`).

During `wp cron event run --all` on fresh installs, `wp_delete_temp_updater_backups` is scheduled mid-execution and is not included in the initial snapshot of events executed by `run --all`. As a result, it remains queued as due `now`, causing subsequent `wp cron event run --due-now` assertions in Behat tests to fail when they expect 0 due events.

This PR adds a `wp cron event run --due-now` step to flush any dynamically scheduled core cron events before asserting 0 due events.

This makes the tests more resilient as they were temporarily failing because https://github.com/wp-cli/wp-cli-tests/pull/337 wasn't merged yet after the most recent minor release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cron event execution messaging to reflect newer WordPress behavior.
  * Improved validation of `--due-now` results by accepting successful execution totals instead of requiring an exact zero-event message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->